### PR TITLE
Updated packages.json

### DIFF
--- a/examples/frontend/package.json
+++ b/examples/frontend/package.json
@@ -8,8 +8,8 @@
         "start": "next start"
     },
     "dependencies": {
-        "@cura/components": "0.0.14",
-        "@cura/hooks": "0.0.6",
+        "@cura/components": "^0.0.14",
+        "@cura/hooks": "^0.0.7",
         "@runwayml/hosted-models": "^0.3.0",
         "@theme-ui/color": "^0.8.4",
         "@theme-ui/match-media": "^0.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -18,7 +18,7 @@
     "author": "Yassine",
     "license": "MIT",
     "dependencies": {
-        "@cura/hooks": "0.0.6",
+        "@cura/hooks": "^0.0.7",
         "@theme-ui/match-media": "^0.12.0",
         "@theme-ui/presets": "^0.6.0",
         "near-api-js": "^0.42.0",


### PR DESCRIPTION
Fix #114 

`@cura/hooks` was outdated in `@cura/components` which caused that error

> Also, added `^` to make sure it's always using the latest version