### PR TITLE
Remove hooks from `MediaObject`

### DIFF
--- a/packages/components/src/MediaObject.tsx
+++ b/packages/components/src/MediaObject.tsx
@@ -1,18 +1,20 @@
 // @ts-nocheck
 /** @jsxImportSource theme-ui */
 
-import { useNFTContentType } from '@cura/hooks'
 import { Placeholder } from './Placeholder'
+
+type ContentType = 'image' | 'video' | 'audio' | 'text' | undefined
 
 type mediaObjectProps = {
     mediaURI: string
+    type: ContentType
     width?: number | string
     height?: number | string
     loading?: boolean
     autoPlay?: boolean
 }
 
-function Text({ width, height, content }) {
+function Text({ mediaURI, width, height }) {
     return (
         <pre
             sx={{
@@ -20,7 +22,7 @@ function Text({ width, height, content }) {
                 height: height,
             }}
         >
-            {content}
+            {mediaURI}
         </pre>
     )
 }
@@ -72,10 +74,15 @@ function Iframe({ mediaURI, width, height }: mediaObjectProps) {
     )
 }
 
+/**
+ * MediaObject
+ *
+ * @param {string} mediaURI - URI to the media or Raw text if type == text
+ * @param {ContentType} type - image | video | audio | text | undefined
+ *
+ */
 export function MediaObject(props: mediaObjectProps) {
-    const { loading, data, content } = useNFTContentType(props.mediaURI)
-
-    if (props.loading || loading) {
+    if (props.loading) {
         return (
             <Placeholder
                 width={props.width}
@@ -84,7 +91,7 @@ export function MediaObject(props: mediaObjectProps) {
             />
         )
     }
-    switch (data) {
+    switch (props.type) {
         case 'image':
             return <Image {...props} />
 
@@ -95,12 +102,9 @@ export function MediaObject(props: mediaObjectProps) {
             return <Audio {...props} />
 
         case 'text':
-            return <Text {...props} content={content} />
-
-        case 'html' || 'other':
-            return <Iframe {...props} />
+            return <Text {...props} />
 
         default:
-            return <></>
+            return <Iframe {...props} />
     }
 }

--- a/packages/components/src/NFTE.tsx
+++ b/packages/components/src/NFTE.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 /** @jsxImportSource theme-ui */
-import { useNFT, useNFTContractMetadata, useNFTReference } from '@cura/hooks'
+import { useNFT, useNFTContractMetadata, useNFTReference, useNFTContentType } from '@cura/hooks'
 
 import { Container } from 'theme-ui'
 import { useBreakpointIndex } from '@theme-ui/match-media'
@@ -64,6 +64,12 @@ export function NFTE({
 
     const mediaUri = validateURI(finalNFTMetadata?.metadata?.media, baseURI)
 
+    // Determine media type
+    const {
+        loading: mediaTypeLoading,
+        data: mediaType,
+    } = useNFTContentType(mediaUri || '')
+
     let error =
         NFTContractMetadataError ||
         NFTError ||
@@ -93,9 +99,10 @@ export function NFTE({
                 <>
                     <MediaObject
                         mediaURI={mediaUri || ''}
+                        type={mediaType}
                         width={canvasSize}
                         height={canvasSize}
-                        loading={loading}
+                        loading={loading && mediaTypeLoading}
                     />
                     <Metadata
                         data={finalNFTMetadata}

--- a/packages/components/src/stories/MediaObject.stories.tsx
+++ b/packages/components/src/stories/MediaObject.stories.tsx
@@ -15,14 +15,31 @@ const Template: ComponentStory<typeof MediaObject> = (args) => (
 
 export const Text = Template.bind({})
 Text.args = {
-    mediaURI:
-        'https://zora-prod.mypinata.cloud/ipfs/bafybeiaevcepa5gwys3ylxtrooxfvv7k2gkxj4kllrid6bofzjdtqrncyi',
+    mediaURI: `
+    I wake at a creek
+    drop like a beggar and drink
+    from the small cold stream
+    
+    
+    A star crashes near
+    and a devil emerges 
+    smoldering, laughing 
+    
+    I point at the sun
+    and the ghoul’s face splits in half
+    and screams out madly 
+    
+    I rise and fall back
+    as it overtakes me there,
+    I'm laughing now too 👀`,
+    type: 'text',
 }
 
 export const Video = Template.bind({})
 Video.args = {
     mediaURI:
         'https://d2iccaf7eutw5f.cloudfront.net/0xabEFBc9fD2F806065b4f3C237d4b59D9A97Bcac7/2410/large',
+    type: 'video',
     width: 300,
     height: 200,
     autoPlay: true,
@@ -32,11 +49,13 @@ export const Audio = Template.bind({})
 Audio.args = {
     mediaURI:
         'https://d2iccaf7eutw5f.cloudfront.net/0xabEFBc9fD2F806065b4f3C237d4b59D9A97Bcac7/5628/large',
+    type: 'audio',
 }
 
 export const Image = Template.bind({})
 Image.args = {
     mediaURI: 'https://arweave.net/Ds1ggD5l_oDz0k-8jl4yDTaOWDSl9h6G0eq4zIfkf1U',
+    type: 'image',
     width: 300,
 }
 


### PR DESCRIPTION
closes #143 

### MediaObject
- Replaced `useNFTContentType` with `type` prop which will be provided from parents
- `Text` sub-component now uses `mediaURI` as the text content because it doesn't need a URI and adding more props doesn't seem neccessary
- Added a small doc to the component, to explain how props works
- Made `iframe` the fallback, so if `type` is not provided or unknown, we'll display media using `iframe` because it can handle all type of media.

### MediaObject Story
- Reactivated `MediaObject.stories.tsx` that was excluded because hooks inside it  were causing problems. Now solved.
- Added `type` to `MediaObject.stories.tsx`  and changed text mediaURI to the actual text

### Frontend
- Frontend doesn't need to be updated, because all medias shown are `html` and the default for `MediaObject` is `iframe`

### NFTE
- Unlike the frontend, `NFTE` can display all types of NFTs so I use `useNFTContentType` to determine the media type to show
