### PR TITLE
Frontend | removing repetitive code

### DIFF
--- a/examples/frontend/containers/Layouts/Bids.tsx
+++ b/examples/frontend/containers/Layouts/Bids.tsx
@@ -1,0 +1,23 @@
+// @ts-nocheck
+/** @jsxImportSource theme-ui */
+
+import Layout from '../Layout'
+
+const BidsLayout = ({ children, project }) => {
+
+    return (
+        <Layout project={project}>
+            <div
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    mt: 3,
+                }}
+            >
+                {children}
+            </div>
+        </Layout>
+    )
+}
+
+export default BidsLayout

--- a/examples/frontend/containers/Layouts/Create.tsx
+++ b/examples/frontend/containers/Layouts/Create.tsx
@@ -1,0 +1,66 @@
+// @ts-nocheck
+/** @jsxImportSource theme-ui */
+
+import Layout from '../Layout'
+import { Button } from 'theme-ui'
+import { getFrameWidth } from 'utils/frame-width'
+
+const CreateLayout = ({
+    project,
+    frameComponent,
+    royaltiesComponent,
+    retrieveData,
+    claimDesign,
+}) => {
+    const frameDimension = getFrameWidth()
+
+    return (
+        <Layout project={project}>
+            <div
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'center',
+                }}
+            >
+                <div
+                    sx={{
+                        textAlign: 'center',
+                        mb: 3,
+                    }}
+                >
+                    <Button mx="2" mt="1" onClick={retrieveData} variant="uno">
+                        Design
+                    </Button>
+                    <Button mx="2" mt="1" onClick={claimDesign} variant="due">
+                        Claim
+                    </Button>
+                </div>
+                <div
+                    sx={{
+                        alignSelf: 'center',
+                        alignItems: 'center',
+                        bg: 'gray.3',
+                        display: 'flex',
+                        height: frameDimension,
+                        justifyContent: 'center',
+                        width: frameDimension,
+                    }}
+                >
+                    {frameComponent}
+                </div>
+                <div
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        mt: 3,
+                    }}
+                >
+                    {royaltiesComponent}
+                </div>
+            </div>
+        </Layout>
+    )
+}
+
+export default CreateLayout

--- a/examples/frontend/containers/Layouts/Explore.tsx
+++ b/examples/frontend/containers/Layouts/Explore.tsx
@@ -1,0 +1,62 @@
+// @ts-nocheck
+/** @jsxImportSource theme-ui */
+
+import Layout from '../Layout'
+import { Box, Link, Spinner } from 'theme-ui'
+import InfiniteScroll from 'react-infinite-scroll-component'
+import { MediaObject } from '@cura/components'
+import { getFrameWidth } from 'utils/frame-width'
+
+const ExploreLayout = ({ project, items, loadMore, totalSupply, baseUrl }) => {
+    const designDimension = getFrameWidth(true)
+
+    return (
+        <Layout project={project}>
+            <Box sx={{ textAlign: 'center' }}>
+                <InfiniteScroll
+                    dataLength={items.length}
+                    next={loadMore}
+                    hasMore={totalSupply > items.length}
+                    loader={
+                        <Box width="100%" mt={2}>
+                            <Spinner />
+                        </Box>
+                    }
+                >
+                    {items.map((item, index) => {
+                        return (
+                            <Link
+                                key={index}
+                                href={`${baseUrl}${item.id}`}
+                                m={[1, 2, 3]}
+                                sx={{
+                                    display: 'inline-flex',
+                                    position: 'relative',
+                                    ':hover': {
+                                        opacity: '0.8',
+                                    },
+                                }}
+                            >
+                                <div
+                                    sx={{
+                                        position: 'absolute',
+                                        height: '100%',
+                                        width: '100%',
+                                        zIndex: 1,
+                                    }}
+                                ></div>
+                                <MediaObject
+                                    mediaURI={`https://arweave.net/${item.metadata.media}`}
+                                    width={designDimension}
+                                    height={designDimension}
+                                />
+                            </Link>
+                        )
+                    })}
+                </InfiniteScroll>
+            </Box>
+        </Layout>
+    )
+}
+
+export default ExploreLayout

--- a/examples/frontend/containers/Layouts/ExploreView.tsx
+++ b/examples/frontend/containers/Layouts/ExploreView.tsx
@@ -1,0 +1,35 @@
+// @ts-nocheck
+/** @jsxImportSource theme-ui */
+
+import Layout from '../Layout'
+import { Box, Divider } from 'theme-ui'
+
+const ExploreViewLayout = ({
+    project,
+    frameComponent,
+    metaComponent,
+    royaltiesComponent,
+    bidCreateComponent,
+}) => {
+    return (
+        <Layout project={project}>
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 12,
+                }}
+            >
+                {frameComponent}
+                {metaComponent}
+                <Divider sx={{ width: 300 }} />
+                {royaltiesComponent}
+                <Divider sx={{ width: 300 }} />
+                {bidCreateComponent}
+            </Box>
+        </Layout>
+    )
+}
+
+export default ExploreViewLayout

--- a/examples/frontend/containers/Layouts/View.tsx
+++ b/examples/frontend/containers/Layouts/View.tsx
@@ -1,0 +1,61 @@
+// @ts-nocheck
+/** @jsxImportSource theme-ui */
+
+import Layout from '../Layout'
+import { Button } from 'theme-ui'
+
+const ViewLayout = ({
+    project,
+    frameComponent,
+    biddersComponent,
+    royaltiesComponent,
+    burnDesign,
+}) => {
+
+    return (
+        <Layout project={project}>
+            <>
+                <div
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        mb: 3,
+                    }}
+                >
+                    <Button onClick={burnDesign} variant="red">
+                        Burn
+                    </Button>
+                </div>
+                <div
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                    }}
+                >
+                    {frameComponent}
+                </div>
+                <div
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        mt: 3,
+                    }}
+                >
+                    {biddersComponent}
+                </div>
+
+                <div
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        mt: 3,
+                    }}
+                >
+                    {royaltiesComponent}
+                </div>
+            </>
+        </Layout>
+    )
+}
+
+export default ViewLayout

--- a/examples/frontend/package.json
+++ b/examples/frontend/package.json
@@ -8,7 +8,7 @@
         "start": "next start"
     },
     "dependencies": {
-        "@cura/components": "0.0.15",
+        "@cura/components": "npm:afaithrafcomponents@latest",
         "@cura/hooks": "0.0.9",
         "@runwayml/hosted-models": "^0.3.0",
         "@theme-ui/color": "^0.8.4",

--- a/examples/frontend/pages/cc/[project]/[id].tsx
+++ b/examples/frontend/pages/cc/[project]/[id].tsx
@@ -1,10 +1,9 @@
 // @ts-nocheck
 /** @jsxImportSource theme-ui */
 
-import { Button, Text } from 'theme-ui'
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
-import Layout from '../../../containers/Layout'
+import ViewLayout from '../../../containers/Layouts/View'
 import { Bidders, CreatorShare, MediaObject } from '@cura/components'
 import { alertMessageState, indexLoaderState } from '../../../state/recoil'
 import { useSetRecoilState } from 'recoil'
@@ -86,25 +85,10 @@ const CCProjectID = ({}) => {
     const frameDimension = getFrameWidth()
 
     return (
-        <Layout project={project}>
-            <>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mb: 3,
-                    }}
-                >
-                    <Button onClick={burnDesign} variant="red">
-                        Burn
-                    </Button>
-                </div>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                    }}
-                >
+        <ViewLayout
+            project={project}
+            frameComponent={
+                <>
                     {media && (
                         <MediaObject
                             mediaURI={`https://arweave.net/${media.metadata.media}`}
@@ -112,52 +96,21 @@ const CCProjectID = ({}) => {
                             height={frameDimension}
                         />
                     )}
-                </div>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mb: 3,
-                    }}
-                >
-                    <a
-                        sx={{ textDecoration: 'none' }}
-                        href={`https://viewblock.io/arweave/tx/${media?.metadata.media}`}
-                    >
-                        <Text
-                            sx={{
-                                fontSize: 2,
-                            }}
-                        >
-                            Arweave ↗
-                        </Text>
-                    </a>
-                </div>
-                {bids && (
-                    <div
-                        sx={{
-                            display: 'flex',
-                            justifyContent: 'center',
-                            mt: 3,
-                        }}
-                    >
-                        <Bidders bidders={bids} onAcceptBid={acceptBid} />
-                    </div>
-                )}
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mt: 3,
-                    }}
-                >
-                    <CreatorShare
-                        address={HARDCODED_ROYALTY_ADDRESS}
-                        share={HARDCODED_ROYALTY_SHARE}
-                    />
-                </div>
-            </>
-        </Layout>
+                </>
+            }
+            biddersComponent={
+                <>
+                    {bids && <Bidders bidders={bids} onAcceptBid={acceptBid} />}
+                </>
+            }
+            royaltiesComponent={
+                <CreatorShare
+                    address={HARDCODED_ROYALTY_ADDRESS}
+                    share={HARDCODED_ROYALTY_SHARE}
+                />
+            }
+            burnDesign={burnDesign}
+        />
     )
 }
 

--- a/examples/frontend/pages/cc/[project]/bids.tsx
+++ b/examples/frontend/pages/cc/[project]/bids.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { Spinner } from 'theme-ui'
 import { utils } from 'near-api-js'
 import { BiddersBids } from '@cura/components'
-import Layout from '../../../containers/Layout'
+import BidsLayout from '../../../containers/Layouts/Bids'
 import { useRecoilValue } from 'recoil'
 import { accountState } from 'state/account'
 import { omit } from 'ramda'
@@ -59,14 +59,8 @@ const Bids = () => {
     }
 
     return (
-        <Layout project={project}>
-            <div
-                sx={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    mt: 3,
-                }}
-            >
+        <BidsLayout>
+            <>
                 {removeBidLoader && (
                     <div
                         sx={{
@@ -84,8 +78,8 @@ const Bids = () => {
                         onRemoveBid={removeBid}
                     />
                 )}
-            </div>
-        </Layout>
+            </>
+        </BidsLayout>
     )
 }
 

--- a/examples/frontend/pages/cc/[project]/create.tsx
+++ b/examples/frontend/pages/cc/[project]/create.tsx
@@ -1,10 +1,9 @@
 // @ts-nocheck
 /** @jsxImportSource theme-ui */
 
-import { Button } from 'theme-ui'
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
-import Layout from '../../../containers/Layout'
+import CreateLayout from '../../../containers/Layouts/Create'
 
 import { CreatorShare } from '@cura/components'
 import { alertMessageState, indexLoaderState } from '../../../state/recoil'
@@ -103,38 +102,10 @@ const MLProjectCreate = ({}) => {
     const frameDimension = getFrameWidth()
 
     return (
-        <Layout project={project}>
-            <div
-                sx={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    flexDirection: 'column',
-                }}
-            >
-                <div
-                    sx={{
-                        textAlign: 'center',
-                        mb: 3,
-                    }}
-                >
-                    <Button mx="2" mt="1" onClick={retrieveData} variant="uno">
-                        Design
-                    </Button>
-                    <Button mx="2" mt="1" onClick={claimDesign} variant="due">
-                        Claim
-                    </Button>
-                </div>
-                <div
-                    sx={{
-                        alignSelf: 'center',
-                        alignItems: 'center',
-                        bg: 'gray.3',
-                        display: 'flex',
-                        height: frameDimension,
-                        justifyContent: 'center',
-                        width: frameDimension,
-                    }}
-                >
+        <CreateLayout
+            project={project}
+            frameComponent={
+                <>
                     {creativeCode && (
                         <iframe
                             srcDoc={creativeCode}
@@ -144,21 +115,17 @@ const MLProjectCreate = ({}) => {
                             scrolling="no"
                         ></iframe>
                     )}
-                </div>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mt: 3,
-                    }}
-                >
-                    <CreatorShare
-                        address={HARDCODED_ROYALTY_ADDRESS}
-                        share={HARDCODED_ROYALTY_SHARE}
-                    />
-                </div>
-            </div>
-        </Layout>
+                </>
+            }
+            royaltiesComponent={
+                <CreatorShare
+                    address={HARDCODED_ROYALTY_ADDRESS}
+                    share={HARDCODED_ROYALTY_SHARE}
+                />
+            }
+            retrieveData={retrieveData}
+            claimDesign={claimDesign}
+        />
     )
 }
 

--- a/examples/frontend/pages/cc/[project]/explore/[id].tsx
+++ b/examples/frontend/pages/cc/[project]/explore/[id].tsx
@@ -1,10 +1,9 @@
 // @ts-nocheck
 /** @jsxImportSource theme-ui */
 
-import { Box, Divider } from 'theme-ui'
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
-import Layout from '../../../../containers/Layout'
+import ExploreViewLayout from '../../../../containers/Layouts/ExploreView'
 import {
     CreatorShare,
     Metadata,
@@ -75,42 +74,44 @@ const ExploreToken = () => {
 
     const designDimension = getFrameWidth()
     return (
-        <Layout project={project}>
-            <Box
-                sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    gap: 12,
-                }}
-            >
-                {media && (
-                    <MediaObject
-                        mediaURI={`https://arweave.net/${media?.metadata?.media}`}
-                        width={designDimension}
-                        height={designDimension}
-                    />
-                )}
-                {media && (
-                    <Metadata
-                        data={media}
-                        loading={false}
-                        width={designDimension}
-                    />
-                )}
-                <Divider sx={{ width: 300 }} />
+        <ExploreViewLayout
+            project={project}
+            frameComponent={
+                <>
+                    {media && (
+                        <MediaObject
+                            mediaURI={`https://arweave.net/${media?.metadata?.media}`}
+                            width={designDimension}
+                            height={designDimension}
+                        />
+                    )}
+                </>
+            }
+            metaComponent={
+                <>
+                    {media && (
+                        <Metadata
+                            data={media}
+                            loading={false}
+                            width={designDimension}
+                        />
+                    )}
+                </>
+            }
+            royaltiesComponent={
                 <CreatorShare
                     address={HARDCODED_ROYALTY_ADDRESS}
                     share={HARDCODED_ROYALTY_SHARE}
                 />
-                <Divider sx={{ width: 300 }} />
+            }
+            bidCreateComponent={
                 <BidCreate
                     title={media?.metadata.title}
                     creator={media?.owner_id}
                     onBid={setBid}
                 />
-            </Box>
-        </Layout>
+            }
+        />
     )
 }
 

--- a/examples/frontend/pages/cc/[project]/explore/index.tsx
+++ b/examples/frontend/pages/cc/[project]/explore/index.tsx
@@ -5,14 +5,10 @@ import { useState, useEffect } from 'react'
 import { useSetRecoilState } from 'recoil'
 import { useRouter } from 'next/router'
 import { utils } from 'near-api-js'
-import { Button, Box, Link, Spinner } from 'theme-ui'
-import InfiniteScroll from 'react-infinite-scroll-component'
 
 import { useNFTMethod, useNFTContract } from '@cura/hooks'
-import { MediaObject } from '@cura/components'
 
-import Layout from '../../../../containers/Layout'
-import { getFrameWidth } from 'utils/frame-width'
+import ExploreLayout from '../../../../containers/Layouts/Explore'
 import { mapPathToProject } from 'utils/path-to-project'
 import { alertMessageState } from '../../../../state/recoil'
 
@@ -49,54 +45,15 @@ const Explore = () => {
         }
     }
 
-    const designDimension = getFrameWidth(true)
 
     return (
-        <Layout project={project}>
-            <Box sx={{ textAlign: 'center' }}>
-                <InfiniteScroll
-                    dataLength={items.length}
-                    next={loadMore}
-                    hasMore={totalSupply > items.length}
-                    loader={
-                        <Box width="100%" mt={2}>
-                            <Spinner />
-                        </Box>
-                    }
-                >
-                    {items.map((item, index) => {
-                        return (
-                            <Link
-                                key={index}
-                                href={`/${project}/explore/${item.id}`}
-                                m={[1, 2, 3]}
-                                sx={{
-                                    display: 'inline-flex',
-                                    position: 'relative',
-                                    ':hover': {
-                                        opacity: '0.8',
-                                    },
-                                }}
-                            >
-                                <div
-                                    sx={{
-                                        position: 'absolute',
-                                        height: '100%',
-                                        width: '100%',
-                                        zIndex: 1,
-                                    }}
-                                ></div>
-                                <MediaObject
-                                    mediaURI={`https://arweave.net/${item.metadata.media}`}
-                                    width={designDimension}
-                                    height={designDimension}
-                                />
-                            </Link>
-                        )
-                    })}
-                </InfiniteScroll>
-            </Box>
-        </Layout>
+        <ExploreLayout
+            project={project}
+            items={items}
+            loadMore={loadMore}
+            totalSupply={totalSupply}
+            baseUrl={`/${project}/explore/`}
+        />
     )
 }
 

--- a/examples/frontend/pages/cc/[project]/index.tsx
+++ b/examples/frontend/pages/cc/[project]/index.tsx
@@ -3,12 +3,9 @@
 
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
-import Layout from '../../../containers/Layout'
+import ExploreLayout from '../../../containers/Layouts/Explore'
 import { useNFTMethod, useNearHooksContainer } from '@cura/hooks'
-import Link from 'next/link'
 import { mapPathToProject } from 'utils/path-to-project'
-import { MediaObject } from '@cura/components'
-import { getFrameWidth } from 'utils/frame-width'
 import { useStatusUpdate } from 'utils/hooks-helpers'
 
 const CONTRACT_VIEW_GAS = utils.format.parseNearAmount('0.00000000010') // 100 Tgas
@@ -32,65 +29,14 @@ const CCProject = ({}) => {
         updateStatus
     )
 
-    const frameDimension = getFrameWidth(true)
-
     return (
-        <Layout project={project}>
-            <>
-                <div
-                    sx={{
-                        display: 'flex',
-                        flexDirection: 'row',
-                        justifyContent: 'center',
-                        flexWrap: 'wrap',
-                    }}
-                >
-                    {media &&
-                        media.map(({ id, metadata }) => (
-                            <div sx={{ m: 20 }}>
-                                <Link key={id} href={`/${project}/${id}`}>
-                                    <div
-                                        sx={{
-                                            position: 'relative',
-                                            display: 'inline-block',
-                                            cursor: 'pointer',
-                                            ':hover': {
-                                                opacity: '0.8',
-                                            },
-                                        }}
-                                    >
-                                        <div
-                                            sx={{
-                                                position: 'absolute',
-                                                height: '100%',
-                                                width: '100%',
-                                                zIndex: 1,
-                                                backgroundColor:
-                                                    'rgba(0,0,0,0.0)',
-                                            }}
-                                        ></div>
-                                        <div
-                                            sx={{
-                                                mx: [1, 2, 3],
-                                                my: [1, 2, 3],
-                                                zIndex: 2,
-                                            }}
-                                        >
-                                            {metadata?.media && (
-                                                <MediaObject
-                                                    mediaURI={`https://arweave.net/${metadata.media}`}
-                                                    width={frameDimension}
-                                                    height={frameDimension}
-                                                />
-                                            )}
-                                        </div>
-                                    </div>
-                                </Link>
-                            </div>
-                        ))}
-                </div>
-            </>
-        </Layout>
+        <ExploreLayout
+            project={project}
+            items={media || []}
+            loadMore={() => null}
+            totalSupply={media?.length || 0}
+            baseUrl={`/${project}/`}
+        />
     )
 }
 

--- a/examples/frontend/pages/ml/[project]/[id].tsx
+++ b/examples/frontend/pages/ml/[project]/[id].tsx
@@ -2,10 +2,9 @@
 /** @jsxImportSource theme-ui */
 
 import { useState, useCallback } from 'react'
-import { Button, Flex, Box, Text } from 'theme-ui'
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
-import Layout from '../../../containers/Layout'
+import ViewLayout from '../../../containers/Layouts/View'
 import { CreatorShare, Bidders, MediaObject } from '@cura/components'
 import { alertMessageState, indexLoaderState } from '../../../state/recoil'
 import { useRecoilValue, useSetRecoilState } from 'recoil'
@@ -88,25 +87,10 @@ const MLProject = ({}) => {
     const frameDimension = getFrameWidth()
 
     return (
-        <Layout project={project}>
-            <>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mb: 3,
-                    }}
-                >
-                    <Button onClick={burnDesign} variant="red">
-                        Burn
-                    </Button>
-                </div>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                    }}
-                >
+        <ViewLayout
+            project={project}
+            frameComponent={
+                <>
                     {media && (
                         <MediaObject
                             mediaURI={`https://arweave.net/${media.metadata.media}`}
@@ -114,52 +98,21 @@ const MLProject = ({}) => {
                             height={frameDimension}
                         />
                     )}
-                </div>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mb: 3,
-                    }}
-                >
-                    <a
-                        sx={{ textDecoration: 'none' }}
-                        href={`https://viewblock.io/arweave/tx/${media?.metadata.media}`}
-                    >
-                        <Text
-                            sx={{
-                                fontSize: 2,
-                            }}
-                        >
-                            Arweave ↗
-                        </Text>
-                    </a>
-                </div>
-                {bids && (
-                    <div
-                        sx={{
-                            display: 'flex',
-                            justifyContent: 'center',
-                            mt: 3,
-                        }}
-                    >
-                        <Bidders bidders={bids} onAcceptBid={acceptBid} />
-                    </div>
-                )}
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mt: 3,
-                    }}
-                >
-                    <CreatorShare
-                        address={HARDCODED_ROYALTY_ADDRESS}
-                        share={HARDCODED_ROYALTY_SHARE}
-                    />
-                </div>
-            </>
-        </Layout>
+                </>
+            }
+            biddersComponent={
+                <>
+                    {bids && <Bidders bidders={bids} onAcceptBid={acceptBid} />}
+                </>
+            }
+            royaltiesComponent={
+                <CreatorShare
+                    address={HARDCODED_ROYALTY_ADDRESS}
+                    share={HARDCODED_ROYALTY_SHARE}
+                />
+            }
+            burnDesign={burnDesign}
+        />
     )
 }
 

--- a/examples/frontend/pages/ml/[project]/bids.tsx
+++ b/examples/frontend/pages/ml/[project]/bids.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { Spinner } from 'theme-ui'
 import { utils } from 'near-api-js'
 import { BiddersBids } from '@cura/components'
-import Layout from '../../../containers/Layout'
+import BidsLayout from '../../../containers/Layouts/Bids'
 import { indexLoaderState } from '../../../state/recoil'
 import { useRecoilState, useRecoilValue } from 'recoil'
 import { accountState } from 'state/account'
@@ -61,14 +61,8 @@ const Bids = () => {
     }
 
     return (
-        <Layout project={project}>
-            <div
-                sx={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    mt: 3,
-                }}
-            >
+        <BidsLayout>
+            <>
                 {removeBidLoader && (
                     <div
                         sx={{
@@ -86,8 +80,8 @@ const Bids = () => {
                         onRemoveBid={removeBid}
                     />
                 )}
-            </div>
-        </Layout>
+            </>
+        </BidsLayout>
     )
 }
 

--- a/examples/frontend/pages/ml/[project]/create.tsx
+++ b/examples/frontend/pages/ml/[project]/create.tsx
@@ -4,7 +4,7 @@
 import { Button } from 'theme-ui'
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
-import Layout from '../../../containers/Layout'
+import CreateLayout from '../../../containers/Layouts/Create'
 import { HostedModel } from '@runwayml/hosted-models'
 import { CreatorShare, MediaObject } from '@cura/components'
 import { alertMessageState, indexLoaderState } from '../../../state/recoil'
@@ -138,55 +138,22 @@ const MLProjectCreate = ({}) => {
     const frameDimension = getFrameWidth()
 
     return (
-        <Layout project={project}>
-            <div
-                sx={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    flexDirection: 'column',
-                }}
-            >
-                <div
-                    sx={{
-                        textAlign: 'center',
-                        mb: 3,
-                    }}
-                >
-                    <Button mx="2" mt="1" onClick={retrieveData} variant="uno">
-                        Design
-                    </Button>
-                    <Button mx="2" mt="1" onClick={claimDesign} variant="due">
-                        Claim
-                    </Button>
-                </div>
-                <div
-                    sx={{
-                        alignSelf: 'center',
-                        alignItems: 'center',
-                        bg: 'gray.3',
-                        display: 'flex',
-                        height: frameDimension,
-                        justifyContent: 'center',
-                        width: frameDimension,
-                    }}
-                >
-                    <MediaObject mediaURI={media} width={frameDimension} />
-                </div>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mt: 3,
-                    }}
-                >
-                    <CreatorShare
-                        address={HARDCODED_ROYALTY_ADDRESS}
-                        share={HARDCODED_ROYALTY_SHARE}
-                    />
-                </div>
-            </div>
-        </Layout>
+        <CreateLayout
+            project={project}
+            frameComponent={
+                <MediaObject mediaURI={media} width={frameDimension} />
+            }
+            royaltiesComponent={
+                <CreatorShare
+                    address={HARDCODED_ROYALTY_ADDRESS}
+                    share={HARDCODED_ROYALTY_SHARE}
+                />
+            }
+            retrieveData={retrieveData}
+            claimDesign={claimDesign}
+        />
     )
+
 }
 
 export default MLProjectCreate

--- a/examples/frontend/pages/ml/[project]/explore/[id].tsx
+++ b/examples/frontend/pages/ml/[project]/explore/[id].tsx
@@ -1,10 +1,9 @@
 // @ts-nocheck
 /** @jsxImportSource theme-ui */
 
-import { Box, Divider } from 'theme-ui'
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
-import Layout from '../../../../containers/Layout'
+import ExploreViewLayout from '../../../../containers/Layouts/ExploreView'
 import {
     CreatorShare,
     Metadata,
@@ -75,42 +74,44 @@ const ExploreToken = () => {
 
     const designDimension = getFrameWidth()
     return (
-        <Layout project={project}>
-            <Box
-                sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    gap: 12,
-                }}
-            >
-                {media && (
-                    <MediaObject
-                        mediaURI={`https://arweave.net/${media?.metadata?.media}`}
-                        width={designDimension}
-                        height={designDimension}
-                    />
-                )}
-                {media && (
-                    <Metadata
-                        data={media}
-                        loading={false}
-                        width={designDimension}
-                    />
-                )}
-                <Divider sx={{ width: 300 }} />
+        <ExploreViewLayout
+            project={project}
+            frameComponent={
+                <>
+                    {media && (
+                        <MediaObject
+                            mediaURI={`https://arweave.net/${media?.metadata?.media}`}
+                            width={designDimension}
+                            height={designDimension}
+                        />
+                    )}
+                </>
+            }
+            metaComponent={
+                <>
+                    {media && (
+                        <Metadata
+                            data={media}
+                            loading={false}
+                            width={designDimension}
+                        />
+                    )}
+                </>
+            }
+            royaltiesComponent={
                 <CreatorShare
                     address={HARDCODED_ROYALTY_ADDRESS}
                     share={HARDCODED_ROYALTY_SHARE}
                 />
-                <Divider sx={{ width: 300 }} />
+            }
+            bidCreateComponent={
                 <BidCreate
                     title={media?.metadata.title}
                     creator={media?.owner_id}
                     onBid={setBid}
                 />
-            </Box>
-        </Layout>
+            }
+        />
     )
 }
 

--- a/examples/frontend/pages/ml/[project]/explore/index.tsx
+++ b/examples/frontend/pages/ml/[project]/explore/index.tsx
@@ -5,14 +5,10 @@ import { useState, useEffect } from 'react'
 import { useSetRecoilState } from 'recoil'
 import { useRouter } from 'next/router'
 import { utils } from 'near-api-js'
-import { Box, Link, Spinner } from 'theme-ui'
-import InfiniteScroll from 'react-infinite-scroll-component'
 
 import { useNFTMethod, useNFTContract } from '@cura/hooks'
-import { MediaObject } from '@cura/components'
 
-import Layout from '../../../../containers/Layout'
-import { getFrameWidth } from 'utils/frame-width'
+import ExploreLayout from '../../../../containers/Layouts/Explore'
 import { mapPathToProject } from 'utils/path-to-project'
 import { alertMessageState } from '../../../../state/recoil'
 
@@ -45,54 +41,15 @@ const Explore = () => {
             setAlertMessage(error.toString())
         }
     }
-    const designDimension = getFrameWidth(true)
 
     return (
-        <Layout project={project}>
-            <Box sx={{ textAlign: 'center' }}>
-                <InfiniteScroll
-                    dataLength={items.length}
-                    next={loadMore}
-                    hasMore={totalSupply > items.length}
-                    loader={
-                        <Box width="100%" mt={2}>
-                            <Spinner />
-                        </Box>
-                    }
-                >
-                    {items.map((item, index) => {
-                        return (
-                            <Link
-                                key={index}
-                                href={`/${project}/explore/${item.id}`}
-                                m={[1, 2, 3]}
-                                sx={{
-                                    display: 'inline-flex',
-                                    position: 'relative',
-                                    ':hover': {
-                                        opacity: '0.8',
-                                    },
-                                }}
-                            >
-                                <div
-                                    sx={{
-                                        position: 'absolute',
-                                        height: '100%',
-                                        width: '100%',
-                                        zIndex: 1,
-                                    }}
-                                ></div>
-                                <MediaObject
-                                    mediaURI={`https://arweave.net/${item.metadata.media}`}
-                                    width={designDimension}
-                                    height={designDimension}
-                                />
-                            </Link>
-                        )
-                    })}
-                </InfiniteScroll>
-            </Box>
-        </Layout>
+        <ExploreLayout
+            project={project}
+            items={items}
+            loadMore={loadMore}
+            totalSupply={totalSupply}
+            baseUrl={`/${project}/explore/`}
+        />
     )
 }
 

--- a/examples/frontend/pages/ml/[project]/index.tsx
+++ b/examples/frontend/pages/ml/[project]/index.tsx
@@ -3,12 +3,9 @@
 
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
-import Layout from '../../../containers/Layout'
+import ExploreLayout from '../../../containers/Layouts/Explore'
 import { useNFTMethod, useNearHooksContainer } from '@cura/hooks'
-import Link from 'next/link'
-import { getFrameWidth } from 'utils/frame-width'
 import { useStatusUpdate } from 'utils/hooks-helpers'
-import { MediaObject } from '@cura/components'
 
 const CONTRACT_VIEW_GAS = utils.format.parseNearAmount('0.00000000010') // 100 Tgas
 
@@ -31,43 +28,15 @@ const MLProject = ({}) => {
         updateStatus
     )
 
-    const frameDimension = getFrameWidth(true)
 
     return (
-        <Layout project={project}>
-            <>
-                <div
-                    sx={{
-                        display: 'flex',
-                        flexDirection: 'row',
-                        justifyContent: 'center',
-                        flexWrap: 'wrap',
-                    }}
-                >
-                    {media &&
-                        media.map(({ id, metadata }) => (
-                            <Link href={`/${project}/${id}`}>
-                                <div
-                                    sx={{
-                                        cursor: 'pointer',
-                                        mx: [1, 2, 3],
-                                        my: [1, 2, 3],
-                                        ':hover': {
-                                            opacity: '0.8',
-                                        },
-                                    }}
-                                >
-                                    <MediaObject
-                                        mediaURI={`https://arweave.net/${metadata.media}`}
-                                        width={frameDimension}
-                                        height={frameDimension}
-                                    />
-                                </div>
-                            </Link>
-                        ))}
-                </div>
-            </>
-        </Layout>
+        <ExploreLayout
+            project={project}
+            items={media || []}
+            loadMore={() => null}
+            totalSupply={media?.length || 0}
+            baseUrl={`/${project}/`}
+        />
     )
 }
 

--- a/examples/frontend/pages/share/bids.tsx
+++ b/examples/frontend/pages/share/bids.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { Spinner } from 'theme-ui'
 import { utils } from 'near-api-js'
 import { BiddersBids } from '@cura/components'
-import Layout from '../../containers/Layout'
+import BidsLayout from '../../containers/Layouts/Bids'
 import { useRecoilValue } from 'recoil'
 import { accountState } from 'state/account'
 import { omit } from 'ramda'
@@ -60,14 +60,8 @@ const Bids = () => {
     }
 
     return (
-        <Layout>
-            <div
-                sx={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    mt: 3,
-                }}
-            >
+        <BidsLayout>
+            <>
                 {removeBidLoader && (
                     <div
                         sx={{
@@ -85,8 +79,8 @@ const Bids = () => {
                         onRemoveBid={removeBid}
                     />
                 )}
-            </div>
-        </Layout>
+            </>
+        </BidsLayout>
     )
 }
 

--- a/examples/frontend/pages/share/create.tsx
+++ b/examples/frontend/pages/share/create.tsx
@@ -2,9 +2,8 @@
 /** @jsxImportSource theme-ui */
 
 import { useState } from 'react'
-import { Button, Text } from 'theme-ui'
 import { utils } from 'near-api-js'
-import Layout from '../../containers/Layout'
+import CreateLayout from '../../containers/Layouts/Create'
 import { CreatorShare } from '@cura/components'
 import { alertMessageState, indexLoaderState } from '../../state/recoil'
 import { useSetRecoilState } from 'recoil'
@@ -29,6 +28,7 @@ const SCHEMA_SIZE = 5
 const Create = ({}) => {
     const router = useRouter()
     const contractAdress = router && mapPathToProject(router.asPath)
+    const project = `share`
 
     const { contract } = useNFTContract(contractAdress)
 
@@ -100,38 +100,10 @@ const Create = ({}) => {
     const frameDimension = getFrameWidth()
 
     return (
-        <Layout>
-            <div
-                sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'center',
-                }}
-            >
-                <div
-                    sx={{
-                        textAlign: 'center',
-                        mb: 3,
-                    }}
-                >
-                    <Button mx="2" mt="1" onClick={retrieveData} variant="uno">
-                        Design
-                    </Button>
-                    <Button mx="2" mt="1" onClick={claimDesign} variant="due">
-                        Claim
-                    </Button>
-                </div>
-                <div
-                    sx={{
-                        alignSelf: 'center',
-                        alignItems: 'center',
-                        bg: 'gray.3',
-                        display: 'flex',
-                        height: frameDimension,
-                        justifyContent: 'center',
-                        width: frameDimension,
-                    }}
-                >
+        <CreateLayout
+            project={project}
+            frameComponent={
+                <>
                     {creativeCode && (
                         <iframe
                             srcDoc={creativeCode}
@@ -141,21 +113,17 @@ const Create = ({}) => {
                             scrolling="no"
                         ></iframe>
                     )}
-                </div>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mt: 3,
-                    }}
-                >
-                    <CreatorShare
-                        address={HARDCODED_ROYALTY_ADDRESS}
-                        share={HARDCODED_ROYALTY_SHARE}
-                    />
-                </div>
-            </div>
-        </Layout>
+                </>
+            }
+            royaltiesComponent={
+                <CreatorShare
+                    address={HARDCODED_ROYALTY_ADDRESS}
+                    share={HARDCODED_ROYALTY_SHARE}
+                />
+            }
+            retrieveData={retrieveData}
+            claimDesign={claimDesign}
+        />
     )
 }
 

--- a/examples/frontend/pages/share/explore/[id].tsx
+++ b/examples/frontend/pages/share/explore/[id].tsx
@@ -1,10 +1,9 @@
 // @ts-nocheck
 /** @jsxImportSource theme-ui */
 
-import { Box, Divider } from 'theme-ui'
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
-import Layout from '../../../containers/Layout'
+import ExploreViewLayout from '../../../../containers/Layouts/ExploreView'
 import {
     CreatorShare,
     Metadata,
@@ -73,42 +72,44 @@ const ExploreToken = () => {
 
     const designDimension = getFrameWidth()
     return (
-        <Layout project={project}>
-            <Box
-                sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    gap: 12,
-                }}
-            >
-                {media && (
-                    <MediaObject
-                        mediaURI={`https://arweave.net/${media?.metadata?.media}`}
-                        width={designDimension}
-                        height={designDimension}
-                    />
-                )}
-                {media && (
-                    <Metadata
-                        data={media}
-                        loading={false}
-                        width={designDimension}
-                    />
-                )}
-                <Divider sx={{ width: 300 }} />
+        <ExploreViewLayout
+            project={project}
+            frameComponent={
+                <>
+                    {media && (
+                        <MediaObject
+                            mediaURI={`https://arweave.net/${media?.metadata?.media}`}
+                            width={designDimension}
+                            height={designDimension}
+                        />
+                    )}
+                </>
+            }
+            metaComponent={
+                <>
+                    {media && (
+                        <Metadata
+                            data={media}
+                            loading={false}
+                            width={designDimension}
+                        />
+                    )}
+                </>
+            }
+            royaltiesComponent={
                 <CreatorShare
                     address={HARDCODED_ROYALTY_ADDRESS}
                     share={HARDCODED_ROYALTY_SHARE}
                 />
-                <Divider sx={{ width: 300 }} />
+            }
+            bidCreateComponent={
                 <BidCreate
                     title={media?.metadata.title}
                     creator={media?.owner_id}
                     onBid={setBid}
                 />
-            </Box>
-        </Layout>
+            }
+        />
     )
 }
 

--- a/examples/frontend/pages/share/explore/[id].tsx
+++ b/examples/frontend/pages/share/explore/[id].tsx
@@ -3,7 +3,7 @@
 
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
-import ExploreViewLayout from '../../../../containers/Layouts/ExploreView'
+import ExploreViewLayout from '../../../containers/Layouts/ExploreView'
 import {
     CreatorShare,
     Metadata,

--- a/examples/frontend/pages/share/explore/index.tsx
+++ b/examples/frontend/pages/share/explore/index.tsx
@@ -5,14 +5,10 @@ import { useState, useEffect } from 'react'
 import { useSetRecoilState } from 'recoil'
 import { useRouter } from 'next/router'
 import { utils } from 'near-api-js'
-import { Box, Link, Spinner } from 'theme-ui'
-import InfiniteScroll from 'react-infinite-scroll-component'
 
 import { useNFTMethod, useNFTContract } from '@cura/hooks'
-import { MediaObject } from '@cura/components'
 
-import Layout from '../../../containers/Layout'
-import { getFrameWidth } from 'utils/frame-width'
+import ExploreLayout from '../../../containers/Layouts/Explore'
 import { mapPathToProject } from 'utils/path-to-project'
 import { alertMessageState } from '../../../state/recoil'
 
@@ -46,54 +42,15 @@ const Explore = () => {
         }
     }
 
-    const designDimension = getFrameWidth(true)
 
     return (
-        <Layout project={project}>
-            <Box sx={{ textAlign: 'center' }}>
-                <InfiniteScroll
-                    dataLength={items.length}
-                    next={loadMore}
-                    hasMore={totalSupply > items.length}
-                    loader={
-                        <Box width="100%" mt={2}>
-                            <Spinner />
-                        </Box>
-                    }
-                >
-                    {items.map((item, index) => {
-                        return (
-                            <Link
-                                key={index}
-                                href={`/${project}/explore/${item.id}`}
-                                m={[1, 2, 3]}
-                                sx={{
-                                    display: 'inline-flex',
-                                    position: 'relative',
-                                    ':hover': {
-                                        opacity: '0.8',
-                                    },
-                                }}
-                            >
-                                <div
-                                    sx={{
-                                        position: 'absolute',
-                                        height: '100%',
-                                        width: '100%',
-                                        zIndex: 1,
-                                    }}
-                                ></div>
-                                <MediaObject
-                                    mediaURI={`https://arweave.net/${item.metadata.media}`}
-                                    width={designDimension}
-                                    height={designDimension}
-                                />
-                            </Link>
-                        )
-                    })}
-                </InfiniteScroll>
-            </Box>
-        </Layout>
+        <ExploreLayout
+            project={project}
+            items={items}
+            loadMore={loadMore}
+            totalSupply={totalSupply}
+            baseUrl={`/${project}/explore/`}
+        />
     )
 }
 

--- a/examples/frontend/pages/share/index.tsx
+++ b/examples/frontend/pages/share/index.tsx
@@ -1,9 +1,8 @@
 // @ts-nocheck
 /** @jsxImportSource theme-ui */
 
-import { Button } from 'theme-ui'
 import { utils } from 'near-api-js'
-import Layout from '../../containers/Layout'
+import ViewLayout from '../../containers/Layouts/View'
 import { CreatorShare, Bidders, MediaObject } from '@cura/components'
 import { alertMessageState, indexLoaderState } from '../../state/recoil'
 import { useSetRecoilState } from 'recoil'
@@ -87,25 +86,10 @@ const View = ({}) => {
     const mediaDimension = getFrameWidth()
 
     return (
-        <Layout>
-            <>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mb: 3,
-                    }}
-                >
-                    <Button onClick={burnDesign} variant="red">
-                        Burn
-                    </Button>
-                </div>
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                    }}
-                >
+        <ViewLayout
+            project="share"
+            frameComponent={
+                <>
                     {media?.[0]?.metadata?.media && (
                         <MediaObject
                             mediaURI={`https://arweave.net/${media[0].metadata.media}`}
@@ -113,33 +97,21 @@ const View = ({}) => {
                             height={mediaDimension}
                         />
                     )}
-                </div>
-                {bids && (
-                    <div
-                        sx={{
-                            display: 'flex',
-                            justifyContent: 'center',
-                            mt: 3,
-                        }}
-                    >
-                        <Bidders bidders={bids} onAcceptBid={acceptBid} />
-                    </div>
-                )}
-
-                <div
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        mt: 3,
-                    }}
-                >
-                    <CreatorShare
-                        address={HARDCODED_ROYALTY_ADDRESS}
-                        share={HARDCODED_ROYALTY_SHARE}
-                    />
-                </div>
-            </>
-        </Layout>
+                </>
+            }
+            biddersComponent={
+                <>
+                    {bids && <Bidders bidders={bids} onAcceptBid={acceptBid} />}
+                </>
+            }
+            royaltiesComponent={
+                <CreatorShare
+                    address={HARDCODED_ROYALTY_ADDRESS}
+                    share={HARDCODED_ROYALTY_SHARE}
+                />
+            }
+            burnDesign={burnDesign}
+        />
     )
 }
 


### PR DESCRIPTION
Currently, all projects frontend have the same layout but it's reptetively written on each page.

The goal from this PR is to have the layout of the same pages type defined in just one place, and we would have to pass only important data from the page to the layout.

So for example instead of having to edit `pages/*/create.tsx` for each project, we would have to edit just `Layouts/Create.tsx`.
