### PR TITLE
Fixed contracts tests failing issue

### DIFF
--- a/packages/contracts/as/NFT/assembly/index.ts
+++ b/packages/contracts/as/NFT/assembly/index.ts
@@ -15,6 +15,8 @@ import {
     DESIGN_PRICE,
     GAS_FOR_NFT_APPROVE,
     NFTOnApprovedArgs,
+    StorageBalance,
+    accounts_storage
 } from './models'
 import { NFTContractMetadata, TokenMetadata } from './metadata'
 import {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -25,6 +25,8 @@
         "ora": "^6.0.1"
     },
     "devDependencies": {
+        "@as-pect/cli": "^6.2.4",
+        "asbuild": "^0.2.0",
         "near-sdk-as": "^3.2.3",
         "prettier": "2.5.1"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,7 +52,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@as-pect/cli@npm:^6.0.0":
+"@as-pect/cli@npm:^6.0.0, @as-pect/cli@npm:^6.2.4":
   version: 6.2.4
   resolution: "@as-pect/cli@npm:6.2.4"
   dependencies:
@@ -1786,6 +1786,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cura/contracts@workspace:packages/contracts"
   dependencies:
+    "@as-pect/cli": ^6.2.4
+    asbuild: ^0.2.0
     async: ^3.2.2
     bn.js: ^5.2.0
     chalk: ^5.0.0


### PR DESCRIPTION
### Problem
Some classes were not imported to the `packages/contracts/as/NFT`. Because of that test cases were failing for contracts.

### Solution
- Fixed the class imports. 
- Then another issue came up with yarn 3 due to absent of `@as-pect/cli` & `asbuild` dependencies. It was fixed thanks to @achrafismyname by manually installing those two dependencies.
