### PR TITLE
Fixed Layout confusion when switching between projects

### DIFF
--- a/examples/frontend/containers/Layout.tsx
+++ b/examples/frontend/containers/Layout.tsx
@@ -33,6 +33,7 @@ export default function Layout({ children, project = 'share' }) {
 
     const switchProject = () => {
         setCurrentProject(mapPathToProject(router.asPath));
+        setSignedProject(localStorage.getItem('contractAddress'))
 
         if (
             signedProject &&
@@ -46,7 +47,6 @@ export default function Layout({ children, project = 'share' }) {
     const preSignIn = async () => {
         const project = mapPathToProject(router.asPath)
         if(localStorage.getItem('contractAddress')){
-            localStorage.removeItem('contractAddress')
             await signOut();
         }
         localStorage.setItem('contractAddress', project)
@@ -60,15 +60,11 @@ export default function Layout({ children, project = 'share' }) {
 
     const preSignOut = () => {
         localStorage.removeItem('contractAddress')
-        router.reload(window.location.origin + router.asPath)
         signOut()
+        router.reload(window.location.origin + router.asPath)
     }
 
     useEffect(switchProject, [router.asPath])
-    useEffect(switchProject, [])
-    useEffect(()=>{
-        setSignedProject(localStorage.getItem('contractAddress'))
-    }, [])
 
     // get the last part of the path (e.g. create, view, explore)
     const lastPath = router.pathname.split('/').slice(-1)[0]

--- a/examples/frontend/containers/Menu.tsx
+++ b/examples/frontend/containers/Menu.tsx
@@ -1,20 +1,20 @@
 // @ts-nocheck
 /** @jsxImportSource theme-ui */
 
-import { useNearHooksContainer } from '@cura/hooks'
 import { Menu } from '@cura/components'
 
 export default function MenuContainer({
+    accountId,
     base,
     nextLinkWrapper,
     activeLink,
 }: {
+    accountId: string
     base: string
     nextLinkWrapper: (link: string, children: JSX.Element) => JSX.Element
     activeLink: string
 }) {
-    const { accountId } = useNearHooksContainer()
-
+    
     return (
         <Menu
             accountId={accountId}

--- a/examples/frontend/pages/cc/[project]/explore/index.tsx
+++ b/examples/frontend/pages/cc/[project]/explore/index.tsx
@@ -31,7 +31,7 @@ const Explore = () => {
     )
 
     // hook that contains all the logic of explore page
-    const { items, nextPage } = useNFTExplore(
+    const { items, nextPage, notLogged } = useNFTExplore(
         contractAdress,
         NFT_PER_PAGE
     )
@@ -50,7 +50,7 @@ const Explore = () => {
             project={project}
             items={items}
             loadMore={loadMore}
-            totalSupply={totalSupply}
+            totalSupply={notLogged ? 0 : totalSupply}
             baseUrl={`/${project}/explore/`}
         />
     )
@@ -62,6 +62,7 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
     const [currentPage, setCurrentPage] = useState(0)
     const [data, setData] = useState([])
     const [isLoading, setIsLoading] = useState(true)
+    const [notLogged, setNotLogged] = useState(true)
 
     const from_index = Math.floor(limitPerPage * currentPage)
 
@@ -82,7 +83,7 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
     // Excute function if contract change or currentPage change
     useEffect(() => {
         let signedAddress = localStorage.getItem('contractAddress');
-        
+
         // make sure the user is logged in and the contract is the right contract
         if (
             contract?.account?.accountId &&
@@ -90,7 +91,10 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
             contract.contractId == signedAddress
         ) {
             setIsLoading(true)
+            setNotLogged(false)
             getData()
+        } else {
+            setNotLogged(true)
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [contract,  currentPage])
@@ -99,5 +103,6 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
         items: data,
         loading: isLoading,
         nextPage: () => setCurrentPage(currentPage + 1),
+        notLogged: notLogged,
     }
 }

--- a/examples/frontend/pages/cc/[project]/explore/index.tsx
+++ b/examples/frontend/pages/cc/[project]/explore/index.tsx
@@ -81,10 +81,13 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
 
     // Excute function if contract change or currentPage change
     useEffect(() => {
+        let signedAddress = localStorage.getItem('contractAddress');
+        
         // make sure the user is logged in and the contract is the right contract
         if (
             contract?.account?.accountId &&
-            contract.contractId == contractAdress
+            contract.contractId == contractAdress &&
+            contract.contractId == signedAddress
         ) {
             setIsLoading(true)
             getData()

--- a/examples/frontend/pages/index.tsx
+++ b/examples/frontend/pages/index.tsx
@@ -6,6 +6,8 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { ProjectCard } from '@cura/components'
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
+import { useNearHooksContainer } from '@cura/hooks'
+import { mapPathToProject } from 'utils/path-to-project'
 
 const slideDetails = [
     {
@@ -75,6 +77,8 @@ const Index = () => {
     const [pauseSlider, setPauseSlider] = useState(0)
     const [loading, setLoading] = useState(true)
 
+    const { signOut } = useNearHooksContainer()
+
 
     const slidify = (newDirection: number) => {
         if (pauseSlider) return
@@ -93,6 +97,23 @@ const Index = () => {
         setPage([Math.floor(Math.random() * slideDetails.length), 0])
         setLoading(false)
     }, [])
+
+    const handleClick = async (path, buttonType) =>{
+        if(localStorage.getItem('contractAddress') != mapPathToProject(path)){
+            localStorage.removeItem('contractAddress')
+            await signOut();
+        }
+
+        if(buttonType == 'create') {
+            router.push(
+                slideDetails[page].path + `/create`
+            )
+        } else {
+            router.push(
+                slideDetails[page].path + `/explore`
+            )
+        }
+    }
 
     return (
         <div
@@ -150,14 +171,10 @@ const Index = () => {
                                 description={slideDetails[page].description}
                                 tags={slideDetails[page].tags}
                                 onCreateClick={() =>
-                                    router.push(
-                                        slideDetails[page].path + `/create`
-                                    )
+                                    handleClick(slideDetails[page].path, 'create')
                                 }
                                 onExploreClick={() =>
-                                    router.push(
-                                        slideDetails[page].path + `/explore`
-                                    )
+                                    handleClick(slideDetails[page].path, 'explore')
                                 }
                             />
                         </motion.div>

--- a/examples/frontend/pages/ml/[project]/explore/index.tsx
+++ b/examples/frontend/pages/ml/[project]/explore/index.tsx
@@ -79,10 +79,13 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
 
     // Excute function if contract change or currentPage change
     useEffect(() => {
+        let signedAddress = localStorage.getItem('contractAddress');
+        
         // make sure the user is logged in and the contract is the right contract
         if (
             contract?.account?.accountId &&
-            contract.contractId == contractAdress
+            contract.contractId == contractAdress &&
+            contract.contractId == signedAddress
         ) {
             setIsLoading(true)
             getData()

--- a/examples/frontend/pages/ml/[project]/explore/index.tsx
+++ b/examples/frontend/pages/ml/[project]/explore/index.tsx
@@ -31,7 +31,7 @@ const Explore = () => {
     )
 
     // hook that contains all the logic of explore page
-    const { items, nextPage } = useNFTExplore(contractAdress, NFT_PER_PAGE)
+    const { items, nextPage, notLogged } = useNFTExplore(contractAdress, NFT_PER_PAGE)
 
     function loadMore() {
         try {
@@ -47,7 +47,7 @@ const Explore = () => {
             project={project}
             items={items}
             loadMore={loadMore}
-            totalSupply={totalSupply}
+            totalSupply={notLogged ? 0 : totalSupply}
             baseUrl={`/${project}/explore/`}
             type="image"
         />
@@ -60,6 +60,7 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
     const [currentPage, setCurrentPage] = useState(0)
     const [data, setData] = useState([])
     const [isLoading, setIsLoading] = useState(true)
+    const [notLogged, setNotLogged] = useState(true)
 
     const from_index = Math.floor(limitPerPage * currentPage)
 
@@ -80,7 +81,7 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
     // Excute function if contract change or currentPage change
     useEffect(() => {
         let signedAddress = localStorage.getItem('contractAddress');
-        
+
         // make sure the user is logged in and the contract is the right contract
         if (
             contract?.account?.accountId &&
@@ -88,7 +89,10 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
             contract.contractId == signedAddress
         ) {
             setIsLoading(true)
+            setNotLogged(false)
             getData()
+        } else {
+            setNotLogged(true)
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [contract, currentPage])
@@ -97,5 +101,6 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
         items: data,
         loading: isLoading,
         nextPage: () => setCurrentPage(currentPage + 1),
+        notLogged: notLogged,
     }
 }

--- a/examples/frontend/pages/share/explore/index.tsx
+++ b/examples/frontend/pages/share/explore/index.tsx
@@ -31,7 +31,7 @@ const Explore = () => {
     )
 
     // hook that contains all the logic of explore page
-    const { items, nextPage } = useNFTExplore(contractAdress, NFT_PER_PAGE)
+    const { items, nextPage, notLogged } = useNFTExplore(contractAdress, NFT_PER_PAGE)
 
     function loadMore() {
         try {
@@ -47,7 +47,7 @@ const Explore = () => {
             project={project}
             items={items}
             loadMore={loadMore}
-            totalSupply={totalSupply}
+            totalSupply={notLogged ? 0 : totalSupply}
             baseUrl={`/${project}/explore/`}
         />
     )
@@ -59,6 +59,7 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
     const [currentPage, setCurrentPage] = useState(0)
     const [data, setData] = useState([])
     const [isLoading, setIsLoading] = useState(true)
+    const [notLogged, setNotLogged] = useState(true)
 
     const from_index = Math.floor(limitPerPage * currentPage)
 
@@ -79,15 +80,18 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
     // Excute function if contract change or currentPage change
     useEffect(() => {
         let signedAddress = localStorage.getItem('contractAddress');
-        
+
         // make sure the user is logged in and the contract is the right contract
         if (
             contract?.account?.accountId &&
             contract.contractId == contractAdress &&
             contract.contractId == signedAddress
         ) {
+            setNotLogged(false)
             setIsLoading(true)
             getData()
+        } else {
+            setNotLogged(true)
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [contract, currentPage])
@@ -96,5 +100,6 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
         items: data,
         loading: isLoading,
         nextPage: () => setCurrentPage(currentPage + 1),
+        notLogged: notLogged,
     }
 }

--- a/examples/frontend/pages/share/explore/index.tsx
+++ b/examples/frontend/pages/share/explore/index.tsx
@@ -78,10 +78,13 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
 
     // Excute function if contract change or currentPage change
     useEffect(() => {
+        let signedAddress = localStorage.getItem('contractAddress');
+        
         // make sure the user is logged in and the contract is the right contract
         if (
             contract?.account?.accountId &&
-            contract.contractId == contractAdress
+            contract.contractId == contractAdress &&
+            contract.contractId == signedAddress
         ) {
             setIsLoading(true)
             getData()


### PR DESCRIPTION
## Problem
When switching between projects, sometimes it is showing previous logged project details and account in the screen for around 1 second or so. It might be confusing for some users. It is happening because signet function get a second to complete the execution.

## Solution

- When current project id and previously logged project id are not same, `accountId` is not passing to the `Menu` and `Header` components. Therefore it will display the login page. In the meantime, `signOut` function get executed.

- Then got another error when redirecting to the `explore page` directly from `projects catalog page`. It is happening because previous project is not logged out. Therefore added a `signOut` function before redirecting to the `explore page`.
