### PR TITLE
Optimizing smart contract calls

### DIFF
--- a/examples/frontend/pages/cc/[project]/[id].tsx
+++ b/examples/frontend/pages/cc/[project]/[id].tsx
@@ -8,7 +8,7 @@ import { Bidders, CreatorShare, MediaObject } from '@cura/components'
 import { alertMessageState, indexLoaderState } from '../../../state/recoil'
 import { useSetRecoilState } from 'recoil'
 import { mapPathToProject } from 'utils/path-to-project'
-import { useNFTContract, useNFTMethod, useMarketMethod } from '@cura/hooks'
+import { useNFTContract, useNFTViewMethod, useMarketMethod } from '@cura/hooks'
 import { useStatusUpdate } from 'utils/hooks-helpers'
 
 const CONTRACT_BURN_GAS = utils.format.parseNearAmount(`0.00000000029`) // 290 Tgas
@@ -29,14 +29,13 @@ const CCProjectID = () => {
     const project = `cc/${router.query.project}`
     const { contract } = useNFTContract(`${mapPathToProject(router.asPath)}`)
 
-    const { data: media } = useNFTMethod(
+    const { data: media } = useNFTViewMethod(
         `${mapPathToProject(router.asPath)}`,
         `nft_token`,
         {
             token_id: router.query.id,
             limit: 2,
         },
-        undefined,
         updateStatus
     )
 

--- a/examples/frontend/pages/cc/[project]/explore/[id].tsx
+++ b/examples/frontend/pages/cc/[project]/explore/[id].tsx
@@ -14,7 +14,7 @@ import { alertMessageState, indexLoaderState } from '../../../../state/recoil'
 import { useSetRecoilState } from 'recoil'
 import {
     useNFTContract,
-    useNFTMethod,
+    useNFTViewMethod,
     useNearHooksContainer,
 } from '@cura/hooks'
 import { useStatusUpdate } from 'utils/hooks-helpers'
@@ -37,14 +37,13 @@ const ExploreToken = () => {
     const { contract } = useNFTContract(contractAdress)
     const { accountId } = useNearHooksContainer()
 
-    const { data: media } = useNFTMethod(
+    const { data: media } = useNFTViewMethod(
         `${contractAdress}`,
         `nft_token`,
         {
             token_id: router.query.id,
             limit: 2,
         },
-        undefined,
         updateStatus
     )
 

--- a/examples/frontend/pages/cc/[project]/explore/index.tsx
+++ b/examples/frontend/pages/cc/[project]/explore/index.tsx
@@ -4,15 +4,12 @@
 import { useState, useEffect } from 'react'
 import { useSetRecoilState } from 'recoil'
 import { useRouter } from 'next/router'
-import { utils } from 'near-api-js'
 
-import { useNFTMethod, useNFTContract } from '@cura/hooks'
+import { useNFTViewMethod, useNFTContract } from '@cura/hooks'
 
 import ExploreLayout from '../../../../containers/layouts/Explore'
 import { mapPathToProject } from 'utils/path-to-project'
 import { alertMessageState } from '../../../../state/recoil'
-
-const CONTRACT_RANDOM_GAS = utils.format.parseNearAmount(`0.00000000020`) // 200 Tgas
 
 const NFT_PER_PAGE = 4
 
@@ -24,17 +21,14 @@ const Explore = () => {
     const project = `cc/${router.query.project}`
 
     // get total supply, which we need to detect if all NFTs are loaded
-    const { data: totalSupply } = useNFTMethod(
+    const { data: totalSupply } = useNFTViewMethod(
         contractAdress,
         `nft_total_supply`,
         {}
     )
 
     // hook that contains all the logic of explore page
-    const { items, nextPage } = useNFTExplore(
-        contractAdress,
-        NFT_PER_PAGE
-    )
+    const { items, nextPage } = useNFTExplore(contractAdress, NFT_PER_PAGE)
 
     function loadMore() {
         try {
@@ -68,13 +62,10 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
     const { contract } = useNFTContract(contractAdress)
 
     async function getData() {
-        const newData = await contract.nft_tokens(
-            {
-                from_index: from_index ? from_index.toString() : `0`, // prevent toString() from converting 0 to NaN
-                limit: limitPerPage,
-            },
-            CONTRACT_RANDOM_GAS
-        )
+        const newData = await contract.nft_tokens({
+            from_index: from_index ? from_index.toString() : `0`, // prevent toString() from converting 0 to NaN
+            limit: limitPerPage,
+        })
         setData([...data, ...newData])
         setIsLoading(false)
     }
@@ -89,8 +80,8 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
             setIsLoading(true)
             getData()
         }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [contract,  currentPage])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [contract, currentPage])
 
     return {
         items: data,

--- a/examples/frontend/pages/cc/[project]/index.tsx
+++ b/examples/frontend/pages/cc/[project]/index.tsx
@@ -1,14 +1,11 @@
 // @ts-nocheck
 /** @jsxImportSource theme-ui */
 
-import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
 import ExploreLayout from '../../../containers/layouts/Explore'
-import { useNFTMethod, useNearHooksContainer } from '@cura/hooks'
+import { useNFTViewMethod, useNearHooksContainer } from '@cura/hooks'
 import { mapPathToProject } from 'utils/path-to-project'
 import { useStatusUpdate } from 'utils/hooks-helpers'
-
-const CONTRACT_VIEW_GAS = utils.format.parseNearAmount(`0.00000000010`) // 100 Tgas
 
 const CCProject = () => {
     const router = useRouter()
@@ -19,13 +16,12 @@ const CCProject = () => {
 
     const project = `cc/${router.query.project}`
 
-    const { data: media } = useNFTMethod(
+    const { data: media } = useNFTViewMethod(
         `${mapPathToProject(router.asPath)}`,
         `nft_tokens_for_owner`,
         {
             account_id: accountId,
         },
-        CONTRACT_VIEW_GAS,
         updateStatus
     )
 

--- a/examples/frontend/pages/ml/[project]/[id].tsx
+++ b/examples/frontend/pages/ml/[project]/[id].tsx
@@ -7,7 +7,7 @@ import ViewLayout from '../../../containers/layouts/View'
 import { CreatorShare, Bidders, MediaObject } from '@cura/components'
 import { alertMessageState, indexLoaderState } from '../../../state/recoil'
 import { useSetRecoilState } from 'recoil'
-import { useNFTContract, useNFTMethod, useMarketMethod } from '@cura/hooks'
+import { useNFTContract, useNFTViewMethod, useMarketMethod } from '@cura/hooks'
 import { useStatusUpdate } from 'utils/hooks-helpers'
 const CONTRACT_BURN_GAS = utils.format.parseNearAmount(`0.00000000029`) // 290 Tgas
 const MARKET_ACCEPT_BID_GAS = utils.format.parseNearAmount(`0.00000000025`) // 250 Tgas
@@ -29,14 +29,13 @@ const MLProject = () => {
         `ml${router.query.project}.ysn-1_0_0.ysn.testnet`
     )
 
-    const { data: media } = useNFTMethod(
+    const { data: media } = useNFTViewMethod(
         `ml${router.query.project}.ysn-1_0_0.ysn.testnet`,
         `nft_token`,
         {
             token_id: router.query.id,
             limit: 2,
         },
-        undefined,
         updateStatus
     )
 

--- a/examples/frontend/pages/ml/[project]/explore/[id].tsx
+++ b/examples/frontend/pages/ml/[project]/explore/[id].tsx
@@ -14,7 +14,7 @@ import { alertMessageState, indexLoaderState } from '../../../../state/recoil'
 import { useSetRecoilState } from 'recoil'
 import {
     useNFTContract,
-    useNFTMethod,
+    useNFTViewMethod,
     useNearHooksContainer,
 } from '@cura/hooks'
 import { useStatusUpdate } from 'utils/hooks-helpers'
@@ -37,14 +37,13 @@ const ExploreToken = () => {
     const { contract } = useNFTContract(contractAdress)
     const { accountId } = useNearHooksContainer()
 
-    const { data: media } = useNFTMethod(
+    const { data: media } = useNFTViewMethod(
         `${contractAdress}`,
         `nft_token`,
         {
             token_id: router.query.id,
             limit: 2,
         },
-        undefined,
         updateStatus
     )
 

--- a/examples/frontend/pages/ml/[project]/explore/index.tsx
+++ b/examples/frontend/pages/ml/[project]/explore/index.tsx
@@ -6,7 +6,7 @@ import { useSetRecoilState } from 'recoil'
 import { useRouter } from 'next/router'
 import { utils } from 'near-api-js'
 
-import { useNFTMethod, useNFTContract } from '@cura/hooks'
+import { useNFTViewMethod, useNFTContract } from '@cura/hooks'
 
 import ExploreLayout from '../../../../containers/layouts/Explore'
 import { mapPathToProject } from 'utils/path-to-project'
@@ -24,7 +24,7 @@ const Explore = () => {
     const project = `ml/${router.query.project}`
 
     // get total supply, which we need to detect if all NFTs are loaded
-    const { data: totalSupply } = useNFTMethod(
+    const { data: totalSupply } = useNFTViewMethod(
         `${contractAdress}`,
         `nft_total_supply`,
         {}
@@ -70,8 +70,7 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
             {
                 from_index: from_index ? from_index.toString() : `0`, // prevent toString() from converting 0 to NaN
                 limit: limitPerPage,
-            },
-            CONTRACT_RANDOM_GAS
+            }
         )
         setData([...data, ...newData])
         setIsLoading(false)

--- a/examples/frontend/pages/ml/[project]/index.tsx
+++ b/examples/frontend/pages/ml/[project]/index.tsx
@@ -4,7 +4,7 @@
 import { utils } from 'near-api-js'
 import { useRouter } from 'next/router'
 import ExploreLayout from '../../../containers/layouts/Explore'
-import { useNFTMethod, useNearHooksContainer } from '@cura/hooks'
+import { useNFTViewMethod, useNearHooksContainer } from '@cura/hooks'
 import { useStatusUpdate } from 'utils/hooks-helpers'
 
 const CONTRACT_VIEW_GAS = utils.format.parseNearAmount(`0.00000000010`) // 100 Tgas
@@ -18,13 +18,12 @@ const MLProject = () => {
 
     const project = `ml/${router.query.project}`
 
-    const { data: media } = useNFTMethod(
+    const { data: media } = useNFTViewMethod(
         `ml${router.query.project}.ysn-1_0_0.ysn.testnet`,
         `nft_tokens_for_owner`,
         {
             account_id: accountId,
         },
-        CONTRACT_VIEW_GAS,
         updateStatus
     )
 

--- a/examples/frontend/pages/share/explore/[id].tsx
+++ b/examples/frontend/pages/share/explore/[id].tsx
@@ -14,7 +14,7 @@ import { alertMessageState, indexLoaderState } from '../../../state/recoil'
 import { useSetRecoilState } from 'recoil'
 import {
     useNFTContract,
-    useNFTMethod,
+    useNFTViewMethod,
     useNearHooksContainer,
 } from '@cura/hooks'
 import { useStatusUpdate } from 'utils/hooks-helpers'
@@ -37,13 +37,12 @@ const ExploreToken = () => {
     const { contract } = useNFTContract(contractAdress)
     const { accountId } = useNearHooksContainer()
 
-    const { data: media } = useNFTMethod(
+    const { data: media } = useNFTViewMethod(
         contractAdress,
         `nft_token`,
         {
             token_id: router.query.id,
         },
-        undefined,
         updateStatus
     )
 

--- a/examples/frontend/pages/share/explore/index.tsx
+++ b/examples/frontend/pages/share/explore/index.tsx
@@ -6,7 +6,7 @@ import { useSetRecoilState } from 'recoil'
 import { useRouter } from 'next/router'
 import { utils } from 'near-api-js'
 
-import { useNFTMethod, useNFTContract } from '@cura/hooks'
+import { useNFTViewMethod, useNFTContract } from '@cura/hooks'
 
 import ExploreLayout from '../../../containers/layouts/Explore'
 import { mapPathToProject } from 'utils/path-to-project'
@@ -24,7 +24,7 @@ const Explore = () => {
     const project = `share`
 
     // get total supply, which we need to detect if all NFTs are loaded
-    const { data: totalSupply } = useNFTMethod(
+    const { data: totalSupply } = useNFTViewMethod(
         contractAdress,
         `nft_total_supply`,
         {}
@@ -65,13 +65,10 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
     const { contract } = useNFTContract(contractAdress)
 
     async function getData() {
-        const newData = await contract.nft_tokens(
-            {
-                from_index: from_index ? from_index.toString() : `0`, // prevent toString() from converting 0 to NaN
-                limit: limitPerPage,
-            },
-            CONTRACT_RANDOM_GAS
-        )
+        const newData = await contract.nft_tokens({
+            from_index: from_index ? from_index.toString() : `0`, // prevent toString() from converting 0 to NaN
+            limit: limitPerPage,
+        })
         setData([...data, ...newData])
         setIsLoading(false)
     }
@@ -86,7 +83,7 @@ function useNFTExplore(contractAdress: string, limitPerPage = 4) {
             setIsLoading(true)
             getData()
         }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [contract, currentPage])
 
     return {

--- a/examples/frontend/pages/share/index.tsx
+++ b/examples/frontend/pages/share/index.tsx
@@ -6,13 +6,12 @@ import ViewLayout from '../../containers/layouts/View'
 import { CreatorShare, Bidders, MediaObject } from '@cura/components'
 import { alertMessageState, indexLoaderState } from '../../state/recoil'
 import { useSetRecoilState } from 'recoil'
-import { useNFTMethod, useNFTContract } from '@cura/hooks'
+import { useNFTViewMethod, useNFTContract } from '@cura/hooks'
 import { useNearHooksContainer, useMarketMethod } from '@cura/hooks'
 import { useStatusUpdate } from 'utils/hooks-helpers'
 import { useRouter } from 'next/router'
 import { mapPathToProject } from 'utils/path-to-project'
 
-const CONTRACT_VIEW_GAS = utils.format.parseNearAmount(`0.00000000010`) // 100 Tgas
 const CONTRACT_BURN_GAS = utils.format.parseNearAmount(`0.00000000029`) // 290 Tgas
 const MARKET_ACCEPT_BID_GAS = utils.format.parseNearAmount(`0.00000000025`) // 250 Tgas
 const YOCTO_NEAR = utils.format.parseNearAmount(`0.000000000000000000000001`)
@@ -33,13 +32,12 @@ const View = () => {
 
     const { accountId } = useNearHooksContainer()
 
-    const { data: media } = useNFTMethod(
+    const { data: media } = useNFTViewMethod(
         `${contractAdress}`,
         `nft_tokens_for_owner`,
         {
             account_id: accountId,
         },
-        CONTRACT_VIEW_GAS,
         updateStatus
     )
 

--- a/packages/hooks/src/NFT/useNFTViewMethod.ts
+++ b/packages/hooks/src/NFT/useNFTViewMethod.ts
@@ -42,18 +42,22 @@ const fetchNFTView = async (
  * @param {string} contractAddress - contract adress
  * @param {string} methodName - the view method to execute
  * @param {object} params - method parameters
+ * @param {object} updateStatus
  * @returns {useNFTViewMethodType} { error, loading, data }
  */
 
 export function useNFTViewMethod(
     contractAddress: string,
     methodName: string,
-    params?: object
+    params?: object,
+    updateStatus?: () => void
 ): useNFTViewMethodType {
     const { data, error } = useSWR(
         [contractAddress, methodName, JSON.stringify(params || {})],
         fetchNFTView
     )
+
+    updateStatus && updateStatus(error, data)
 
     return {
         error: error,

--- a/packages/hooks/src/NFT/useNFTViewMethod.ts
+++ b/packages/hooks/src/NFT/useNFTViewMethod.ts
@@ -15,20 +15,31 @@ const fetchNFTView = async (
     methodName: string,
     serializedParams: string
 ) => {
-    const near = await connect({
-        networkId,
-        nodeUrl,
-        deps: {
-            keyStore: undefined,
-        },
-    })
-    const account = await near.account(null)
+    let contract
 
-    const contract = await new Contract(
-        account,
-        contractAddress,
-        getContractMethods('nft')
-    )
+    if (window.near_contracts && window.near_contracts[contractAddress]) {
+        contract = window.near_contracts[contractAddress]
+        console.log('using cached contract')
+    } else {
+        console.log('setting new contract')
+        const near = await connect({
+            networkId,
+            nodeUrl,
+            deps: {
+                keyStore: undefined,
+            },
+        })
+        const account = await near.account(null)
+        contract = await new Contract(
+            account,
+            contractAddress,
+            getContractMethods('nft')
+        )
+        if (!window.near_contracts) {
+            window.near_contracts = {}
+        }
+        window.near_contracts[contractAddress] = contract
+    }
 
     const params = JSON.parse(serializedParams)
     return await contract[methodName]({ ...params }).then((res) => {

--- a/packages/hooks/src/near-utils.ts
+++ b/packages/hooks/src/near-utils.ts
@@ -31,11 +31,15 @@ export function getContractMethods(contractName: string) {
                     'generate',
                     'claim_media',
                     'burn_design',
-                    'view_media',
-                    'nft_tokens',
-                    'nft_tokens_for_owner',
                 ],
-                viewMethods: ['nft_total_supply', 'nft_metadata', 'nft_token'],
+                viewMethods: [
+                    'nft_total_supply',
+                    'nft_metadata',
+                    'nft_token',
+                    'nft_tokens_for_owner',
+                    'nft_tokens',
+                    'view_media',
+                ],
             }
         case 'market':
             return {


### PR DESCRIPTION
The goal from this PR is to optimizing the calling of smart contracts

1. All view methods (nft_tokens, nft_metadata...), now are being called as a view method using the `useNFTViewMethod`

2. `useNFTViewMethod` doesn't require user to be logged in, so it can allow us in the future to let users explore NFTs without having to connect and only ask for login if user is trying a call method.

3. As requested, I tried to cache the contract called in `useNFTViewMethod`. The first time a user call a contract, it generates a new contract instance and save it to a global object in `window`. This will alow to store any amount of contracts for other calls in the same session.

4. Added `updateStatue` to `useNFTViewMethod` because the frontend code already had it for `useNFTMethod`
