### PR TITLE
Fix mainnet links

### DIFF
--- a/packages/components/src/History.tsx
+++ b/packages/components/src/History.tsx
@@ -1,8 +1,10 @@
 import {Box, Heading, Text, Link} from "theme-ui";
 import moment from "moment";
 
-const EXPLORER_URL = process?.env?.NEAR_ENV == 'mainnet' ?
+const EXPLORER_URL = process.env.NEAR_ENV == 'mainnet' ?
     'https://explorer.near.org' : 'https://explorer.testnet.near.org';
+
+console.log(process.env.NEAR_ENV);
 
 type historyProps = {
     type: string

--- a/packages/components/src/History.tsx
+++ b/packages/components/src/History.tsx
@@ -1,8 +1,8 @@
 import {Box, Heading, Text, Link} from "theme-ui";
 import moment from "moment";
 
-const EXPLORER_URL = process.env.NEAR_ENV == 'mainnet' ?
-    'https://explorer.near.org' : 'https://explorer.testnet.near.org';
+const EXPLORER_URL = process.env.NEAR_ENV == 'testnet' ?
+    'https://explorer.testnet.near.org' : 'https://explorer.near.org';
 
 console.log(process.env.NEAR_ENV);
 

--- a/packages/components/src/Metadata.tsx
+++ b/packages/components/src/Metadata.tsx
@@ -3,8 +3,10 @@
 import { Box, Flex, Heading, Text, Link } from 'theme-ui'
 import { Placeholder } from './Placeholder'
 
-const EXPLORER_URL = process?.env?.NEAR_ENV == 'mainnet' ?
-    'https://explorer.near.org' : 'https://explorer.testnet.near.org';
+const EXPLORER_URL = process.env.NEAR_ENV == 'testnet' ?
+    'https://explorer.testnet.near.org' : 'https://explorer.near.org';
+
+console.log(process.env.NEAR_ENV);
 
 type NFTMetadataType = {
     creator_id?: string


### PR DESCRIPTION
It seems like `next.config.js` `NEAR_ENV` is not available in `@cura/components` and so I decided to default to __mainnet__ links. At least it solves the issue on the main front-end. For testnet, it's not critical if currently, it doesn't work correctly. 